### PR TITLE
Fix repositories revision view 'Missing template' 

### DIFF
--- a/app/views/repositories/revision.html.erb
+++ b/app/views/repositories/revision.html.erb
@@ -1,6 +1,7 @@
 <%
    original_partial = File.join(Rails.root, 'app' ,'views', 'repositories', 'revision.html.erb')
-   html = capture { render :template => original_partial }
+   template = File.read(original_partial)
+   html = capture { render :inline => template }
    if !!plugin_redmine_revision_branches('display_under_single_revision') && @changeset.scmid.present?
     html = insert_branches_detail(html, @changeset)
   end


### PR DESCRIPTION
On the latest version of Redmine (5.1.3.stable) I get an error when loading original file

redmine_1  | W, [2024-08-05T11:35:33.674996 #1]  WARN -- : Missing template, responding with 404: Missing template usr/src/redmine/app/views/repositories/revision.html.erb with {:locale=>[:"en-GB", :en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :slim, :rsb]}. Searched in:
redmine_1  |   * "/usr/src/redmine/plugins/redmine_revision_branches/app/views"
redmine_1  |   * "/usr/src/redmine/app/views"
redmine_1  |   * "/usr/local/bundle/gems/render_async-2.1.11/app/views"
redmine_1  |   * "/usr/src/redmine/plugins/additionals/app/views"
redmine_1  |   * "/usr/src/redmine/plugins/additional_tags/app/views"

Looks like it's related to this: https://github.com/rails/rails/issues/39118

Based on info in that Rails issue, this change fetches and renders the original view file in a way which works on the latest Redmine
